### PR TITLE
use LTO and define the build profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,27 @@ allan = "0.2.1"
 log = "0.3.6"
 pad = "0.1.4"
 time = "0.1.35"
+
+[profile.dev]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+
+[profile.bench]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ This will produce a binary at `./target/release/timemark` which can be run in-pl
 ## Sample Benchmark Output
 
 ```
-test tests::bench_instant_sub     ... bench:          60 ns/iter (+/- 2)
-test tests::bench_ns_sub          ... bench:          39 ns/iter (+/- 1)
-test tests::bench_precise_time_ns ... bench:          20 ns/iter (+/- 1)
+test tests::bench_instant_sub     ... bench:          57 ns/iter (+/- 3)
+test tests::bench_ns_sub          ... bench:          39 ns/iter (+/- 13)
+test tests::bench_precise_time_ns ... bench:          19 ns/iter (+/- 0)
 test tests::bench_rdtsc           ... bench:           8 ns/iter (+/- 0)
-test tests::bench_time_instant    ... bench:          26 ns/iter (+/- 1)
+test tests::bench_time_instant    ... bench:          25 ns/iter (+/- 1)
 ```
 
 Here we can see the added expense of working with std::time::Instant. Both subtraction of the `Instant` as well as reading it are longer than time::precise_time_ns(). Reading the CPU TSC is much faster than either method.


### PR DESCRIPTION
Throw LTO on the build profile. Make Dev == Bench == Release. Cause why not?

This gets me to:

```
test tests::bench_instant_sub     ... bench:          57 ns/iter (+/- 3)
test tests::bench_ns_sub          ... bench:          39 ns/iter (+/- 13)
test tests::bench_precise_time_ns ... bench:          19 ns/iter (+/- 0)
test tests::bench_rdtsc           ... bench:           8 ns/iter (+/- 0)
test tests::bench_time_instant    ... bench:          25 ns/iter (+/- 1)
```
