### PR TITLE
add serializing instruction to rdtsc()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,6 @@ rpath = false
 lto = true
 debug-assertions = false
 codegen-units = 1
+
+[features]
+amd = []

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,13 +60,24 @@ fn set_log_level(level: usize) {
     });
 }
 
+#[cfg(not(feature = "amd"))]
 #[allow(unused_mut)]
 pub fn rdtsc() -> u64 {
     let mut l: u32;
     let mut m: u32;
     unsafe {
-        asm!("rdtsc" : "={eax}" (l), "={edx}" (m) ::: "volatile");
+        asm!("lfence; rdtsc" : "={eax}" (l), "={edx}" (m) ::: "volatile");
+    }
+    ((m as u64) << 32) | (l as u64)
+}
 
+#[cfg(feature = "amd")]
+#[allow(unused_mut)]
+pub fn rdtsc() -> u64 {
+    let mut l: u32;
+    let mut m: u32;
+    unsafe {
+        asm!("mfence; rdtsc" : "={eax}" (l), "={edx}" (m) ::: "volatile");
     }
     ((m as u64) << 32) | (l as u64)
 }


### PR DESCRIPTION
- add serializing lfence or mfence instruction depending on the "amd" feature flag
- this costs a bit of performance, going from 8ns to 12ns for rdtsc() on my dev laptop
